### PR TITLE
Add GitHub Skills activity to the registration system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. First part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Problem
The GitHub Skills activity announced by the principal was missing from the school activities signup page, despite being officially announced and being part of an important GitHub Certifications program.

## ✅ Solution
Added the GitHub Skills activity to the system with:
- **Description**: Learn practical coding and collaboration skills through GitHub. First part of our GitHub Certifications program to help with college applications.
- **Schedule**: Mondays and Thursdays, 3:30 PM - 4:30 PM
- **Max Participants**: 25 students
- **Status**: Open for registration

## 📋 Changes
- Added GitHub Skills entry to the activities dictionary in `src/app.py`
- Activity is now available for student registration immediately

Fixes #6